### PR TITLE
Remove validation of new volume and wal_volume size

### DIFF
--- a/mcs/resource_mcs_db_cluster.go
+++ b/mcs/resource_mcs_db_cluster.go
@@ -502,10 +502,7 @@ func resourceDatabaseClusterUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("volume_size") {
-		old, new := d.GetChange("volume_size")
-		if new.(int) < old.(int) {
-			return fmt.Errorf("the new volume size %d must be larger than the current volume size of %d", new.(int), old.(int))
-		}
+		_, new := d.GetChange("volume_size")
 		var resizeVolumeOpts dbClusterResizeVolumeOpts
 		resizeVolumeOpts.Resize.Volume.Size = new.(int)
 		err := dbClusterAction(DatabaseV1Client, d.Id(), &resizeVolumeOpts).ExtractErr()
@@ -581,9 +578,6 @@ func resourceDatabaseClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if walVolumeOptsNew.Size != walVolumeOptsOld.Size {
-			if walVolumeOptsNew.Size < walVolumeOptsOld.Size {
-				return fmt.Errorf("the new wal volume size %d must be larger than the current volume size of %d", walVolumeOptsNew.Size, walVolumeOptsOld.Size)
-			}
 			var resizeWalVolumeOpts dbClusterResizeWalVolumeOpts
 			resizeWalVolumeOpts.Resize.Volume.Size = walVolumeOptsNew.Size
 			resizeWalVolumeOpts.Resize.Volume.Kind = "wal"

--- a/mcs/resource_mcs_db_instance.go
+++ b/mcs/resource_mcs_db_instance.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -319,34 +318,6 @@ func resourceDatabaseInstance() *schema.Resource {
 				},
 			},
 		},
-		CustomizeDiff: customdiff.All(
-			customdiff.ValidateChange("size", func(old, new, meta interface{}) error {
-				if new.(int) < old.(int) {
-					return fmt.Errorf("the new volume size %d must be larger than the current volume size of %d", new.(int), old.(int))
-				}
-				return nil
-			}),
-			customdiff.ValidateChange("wal_volume", func(old, new, meta interface{}) error {
-				if len(old.([]interface{})) == 0 {
-					return nil
-				}
-
-				walVolumeOptsNew, err := extractDatabaseWalVolume(new.([]interface{}))
-				if err != nil {
-					return fmt.Errorf("unable to determine mcs_db_instance wal_volume")
-				}
-
-				walVolumeOptsOld, err := extractDatabaseWalVolume(old.([]interface{}))
-				if err != nil {
-					return fmt.Errorf("unable to determine mcs_db_instance wal_volume")
-				}
-
-				if walVolumeOptsNew.Size < walVolumeOptsOld.Size {
-					return fmt.Errorf("the new wal volume size %d must be larger than the current volume size of %d", walVolumeOptsNew.Size, walVolumeOptsOld.Size)
-				}
-				return nil
-			}),
-		),
 	}
 }
 


### PR DESCRIPTION
This validation is done on cloud side, and is not required on terraform side
This also fixes of provider crash when wal_volume argument is removed from configuration